### PR TITLE
Only returns the expected object

### DIFF
--- a/islandora_scholar_tombstone.module
+++ b/islandora_scholar_tombstone.module
@@ -103,11 +103,10 @@ function islandora_scholar_tombstone_page_alter(&$page)
 
     $current_embargo = <<<EOQ
     PREFIX is: <info:islandora/islandora-system:def/scholar#>
-    SELECT ?obj ?date
+    SELECT ?date
     FROM <#ri>
         WHERE {
-          ?obj <info:islandora/islandora-system:def/scholar#embargo-until> ?date
-          filter regex(str(?obj), 'info:fedora/$object_embargoed')
+          <info:fedora/$object_embargoed> <info:islandora/islandora-system:def/scholar#embargo-until> ?date
           }
 EOQ;
     if ($count) {


### PR DESCRIPTION
** JIRA Ticket**: https://jira.lib.utk.edu/browse/TRAC-1103

# What does this Pull Request do?
Fixes the embargoed object string compare issue. 
There is a bug with the tombstone module. It isn't applying any changes to the object but it is falsely notifying of an embargo. 

If the URL starts with a value (example utk.ir.td:**35**)

URL: `.../object/utk.ir.td:35`

Any objects that start with the same values (like **35**0, **35**8, **35**00, etc) that have an embargo will report as an the current object is embargoed. 

# What's new?
N/A

# How should this be tested?
Create 10 objects and add an embargo to the 10th one. The PID is important. The first ETD should be utk.ir.td:1 and the 10th should be utk.ir.td:10. Check to see if the embargo message show up on the 10th while the 1st one does not.

# Additional Notes:
n/a 

# Interested parties
@utkdigitalinitiatives/digital-initiatives-developers
